### PR TITLE
fix created_at, updated_at null constraint

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -169,7 +169,9 @@ class Expense(models.Model):
                     'claim_number': expense['claim_number'],
                     'report_title': expense['report_title'],
                     'approved_at': expense['approved_at'],
-                    'payment_number': expense['payment_number']
+                    'payment_number': expense['payment_number'],
+                    'expense_created_at': expense['expense_created_at'],
+                    'expense_updated_at': expense['expense_updated_at'],
                 }
 
             defaults = {
@@ -196,8 +198,6 @@ class Expense(models.Model):
                 'bank_transaction_id': expense['bank_transaction_id'],
                 'spent_at': expense['spent_at'],
                 'posted_at': expense['posted_at'],
-                'expense_created_at': expense['expense_created_at'],
-                'expense_updated_at': expense['expense_updated_at'],
                 'fund_source': SOURCE_ACCOUNT_MAP[expense['source_account_type']],
                 'verified_at': expense['verified_at'],
                 'custom_properties': expense['custom_properties'],

--- a/tests/test_fyle/fixtures.py
+++ b/tests/test_fyle/fixtures.py
@@ -43,7 +43,7 @@ data = {
             'name': 'Administration'
         },
         'cost_center_id': 23166,
-        'created_at': '2024-05-10T07:52:10.551260+00:00',
+        'created_at': None,
         'creator_user_id': 'usVN2WTtPqE7',
         'currency': 'USD',
         'custom_fields': [
@@ -180,7 +180,7 @@ data = {
         'tax_group': None,
         'tax_group_id': None,
         'travel_classes': [],
-        'updated_at': '2024-06-10T11:41:40.779611+00:00',
+        'updated_at': None,
         'user': {
             'email': 'admin1@fyleforimporrttest.in',
             'full_name': 'Theresa Brown',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced expense creation functionality with `expense_created_at` and `expense_updated_at` fields.

- **Tests**
  - Updated test fixtures to initialize `created_at` and `updated_at` fields to `None` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->