### PR TITLE
fix: intacct export url

### DIFF
--- a/apps/sage_intacct/tasks.py
+++ b/apps/sage_intacct/tasks.py
@@ -1738,12 +1738,12 @@ def generate_export_url_and_update_expense(expense_group: ExpenseGroup) -> None:
     """
     try:
         export_id = expense_group.response_logs['url_id']
-        url = 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r={export_id}'.format(
+        url = 'https://www.intacct.com/ia/acct/ur.phtml?.r={export_id}'.format(
             export_id=export_id
         )
     except Exception as error:
         # Defaulting it to Intacct app url, worst case scenario if we're not able to parse it properly
-        url = 'https://www-p02.intacct.com'
+        url = 'https://www.intacct.com'
         logger.error('Error while generating export url %s', error)
 
     expense_group.export_url = url

--- a/scripts/python/fill-accounting-export-summary.py
+++ b/scripts/python/fill-accounting-export-summary.py
@@ -54,7 +54,7 @@ for workspace in workspaces:
             else:
                 if expense_group.response_logs and 'url_id' in expense_group.response_logs:
                     export_id = expense_group.response_logs['url_id']
-                    url = 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r={export_id}'.format(
+                    url = 'https://www.intacct.com/ia/acct/ur.phtml?.r={export_id}'.format(
                         export_id=export_id
                     )
             for expense in expense_group.expenses.filter(accounting_export_summary__state__isnull=True):

--- a/tests/test_sageintacct/fixtures.py
+++ b/tests/test_sageintacct/fixtures.py
@@ -73,7 +73,7 @@ data = {
     'journal_entry_response': {
         'data': {
             'glbatch': {
-                'RECORD_URL': 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw',
+                'RECORD_URL': 'https://www.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw',
                 '#text': '...',
                 'RECORDNO': 6679,
                 'BATCHNO': 249,
@@ -115,10 +115,10 @@ data = {
             }
         }
     },
-    'bill_response': {'status': 'success', 'function': 'create', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b', 'data': {'@listtype': 'objects', '@count': '1', 'apbill': {'RECORDNO': '3430', 'RECORD_URL': 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw',}}},
-    'credit_card_response': {'key': '3430', 'status': 'success', 'function': 'create', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b', 'data': {'@listtype': 'objects', '@count': '1', 'cctransaction': {'RECORDNO': '3430', 'RECORD_URL': 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw',}}},
+    'bill_response': {'status': 'success', 'function': 'create', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b', 'data': {'@listtype': 'objects', '@count': '1', 'apbill': {'RECORDNO': '3430', 'RECORD_URL': 'https://www.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw',}}},
+    'credit_card_response': {'key': '3430', 'status': 'success', 'function': 'create', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b', 'data': {'@listtype': 'objects', '@count': '1', 'cctransaction': {'RECORDNO': '3430', 'RECORD_URL': 'https://www.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw',}}},
     'expense_report_post_response': {'status': 'success', 'function': 'create_expensereport', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b','key': '3430'},
-    'expense_report_response': {'status': 'success', 'function': 'create', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b', 'data': {'@listtype': 'objects', '@count': '1', 'eexpenses': {'RECORDNO': '3430', 'RECORD_URL': 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw', 'STATE': 'Paid'}}},
+    'expense_report_response': {'status': 'success', 'function': 'create', 'controlid': 'a1a61e97-8a53-4390-a5f8-b1d628b2e83b', 'data': {'@listtype': 'objects', '@count': '1', 'eexpenses': {'RECORDNO': '3430', 'RECORD_URL': 'https://www.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw', 'STATE': 'Paid'}}},
     'expense_report_get_bulk': [{'RECORDNO': '3032', 'STATE': 'Paid'}],
     'create_contact': {
         'Contacts': [{
@@ -263,7 +263,7 @@ data = {
             'user_id': 'usqywo0f3nBY',
         },
     ],
-    'get_bill': {'@listtype': 'apbill', '@count': '1', '@totalcount': '1', '@numremaining': '0', '@resultId': '', 'apbill': {'STATE': 'Paid', 'RECORD_URL': 'https://www-p02.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw'}},
+    'get_bill': {'@listtype': 'apbill', '@count': '1', '@totalcount': '1', '@numremaining': '0', '@resultId': '', 'apbill': {'STATE': 'Paid', 'RECORD_URL': 'https://www.intacct.com/ia/acct/ur.phtml?.r=cADOKmBnspC0Y1Mp5umhgD3e2gD3B_6rV45dIYv59zw'}},
     'get_by_query': [{'STATE': 'Paid', 'RECORDNO': '3430'}],
     'get_all_organisations': [
         {
@@ -424,7 +424,7 @@ data = {
             'LEGALCOUNTRY':'None',
             'OPCOUNTRY':'Australia',
             'ADDRESSCOUNTRYDEFAULT':'Australia',
-            'RECORD_URL':'https://www-p02.intacct.com/ia/acct/ur.phtml?.r=5jqUgbnTPWSyfcQt2WN8R_O-Kf-mmZi3S99kptb_bT0'
+            'RECORD_URL':'https://www.intacct.com/ia/acct/ur.phtml?.r=5jqUgbnTPWSyfcQt2WN8R_O-Kf-mmZi3S99kptb_bT0'
         }
     ]],
     'get_locations':[[


### PR DESCRIPTION
### Description
fix: intacct export url

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated all export and record URLs to use "www.intacct.com" instead of "www-p02.intacct.com" for improved consistency and reliability across expense exports and accounting summaries.
- **Tests**
	- Adjusted test data to reflect the updated URL domain for accurate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->