### PR TITLE
fix: update email redirect url from settings to admin app

### DIFF
--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -189,7 +189,7 @@ def run_email_notification(workspace_id: int) -> None:
                         'workspace_id': workspace_id,
                         'export_time': export_time.date() if export_time else datetime.now(),
                         'year': date.today().year,
-                        'app_url': "{0}/app/settings/#/integrations/native_apps?integrationIframeTarget=integrations/intacct".format(settings.FYLE_APP_URL),
+                        'app_url': "{0}/app/admin/#/integrations?integrationIframeTarget=integrations/intacct".format(settings.FYLE_APP_URL),
                         'fyle_url': settings.FYLE_EXPENSE_URL,
                         'integrations_app_url': settings.INTEGRATIONS_APP_URL,
                         'sage_intacct_company_id': intacct.si_company_id


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cz0jv07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the link in email notifications for failed Sage Intacct exports to direct users to the correct admin integrations page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->