### PR TITLE
fix: Skip Export post accounting export Summary when not direct export

### DIFF
--- a/apps/sage_intacct/queue.py
+++ b/apps/sage_intacct/queue.py
@@ -75,7 +75,8 @@ def schedule_journal_entries_creation(
 
             if skip_export:
                 logger.info('Skipping export for expense group %s', expense_group.id)
-                post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
+                if triggered_by == ExpenseImportSourceEnum.DIRECT_EXPORT:
+                    post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
                 continue
 
             task_log, _ = TaskLog.objects.get_or_create(
@@ -176,7 +177,8 @@ def schedule_expense_reports_creation(workspace_id: int, expense_group_ids: list
 
             if skip_export:
                 logger.info('Skipping export for expense group %s', expense_group.id)
-                post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
+                if triggered_by == ExpenseImportSourceEnum.DIRECT_EXPORT:
+                    post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
                 continue
 
             task_log, _ = TaskLog.objects.get_or_create(
@@ -240,7 +242,8 @@ def schedule_bills_creation(workspace_id: int, expense_group_ids: list[str], is_
 
             if skip_export:
                 logger.info('Skipping export for expense group %s', expense_group.id)
-                post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
+                if triggered_by == ExpenseImportSourceEnum.DIRECT_EXPORT:
+                    post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
                 continue
 
             task_log, _ = TaskLog.objects.get_or_create(
@@ -304,7 +307,8 @@ def schedule_charge_card_transaction_creation(workspace_id: int, expense_group_i
             skip_export = validate_failing_export(is_auto_export, interval_hours, expense_group)
             if skip_export:
                 logger.info('Skipping export for expense group %s', expense_group.id)
-                post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
+                if triggered_by == ExpenseImportSourceEnum.DIRECT_EXPORT:
+                    post_accounting_export_summary_for_skipped_exports(expense_group=expense_group, workspace_id=workspace_id)
                 continue
 
             task_log, _ = TaskLog.objects.get_or_create(


### PR DESCRIPTION
### Description
fix: Skip Export post accounting export Summary when not direct export

## Clickup
https://app.clickup.com/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Export summaries for skipped exports will now only be posted when triggered by direct export events, preventing unintended summary postings for other trigger sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->