### PR TITLE
fix: use workspace id instead of org id in e2e delete payload

### DIFF
--- a/apps/internal/serializers.py
+++ b/apps/internal/serializers.py
@@ -26,7 +26,7 @@ class E2ESetupSerializer(serializers.Serializer):
 
 class E2EDestroySerializer(serializers.Serializer):
     """Serializer for E2E Destroy API payload validation"""
-    org_id = serializers.CharField(required=True, help_text="Org ID to destroy")
+    workspace_id = serializers.CharField(required=True, help_text="ID of the workspace to destroy")
 
     # Safety constants for allowed workspace names
     ALLOWED_WORKSPACE_NAMES = [
@@ -44,13 +44,13 @@ class E2EDestroySerializer(serializers.Serializer):
             )
         return attrs
 
-    def validate_org_id(self, value: str) -> str:
+    def validate_workspace_id(self, value: str) -> str:
         """Validate org ID and perform safety checks"""
         # Find and validate workspace
         try:
-            workspace = Workspace.objects.get(fyle_org_id=value)
+            workspace = Workspace.objects.get(id=value)
         except Workspace.DoesNotExist:
-            raise serializers.ValidationError(f"No workspace found for org_id: {value}")
+            raise serializers.ValidationError(f"No workspace found for id: {value}")
 
         # CRITICAL SAFETY CHECK: Validate workspace name
         if workspace.name not in self.ALLOWED_WORKSPACE_NAMES:

--- a/apps/internal/serializers.py
+++ b/apps/internal/serializers.py
@@ -26,7 +26,7 @@ class E2ESetupSerializer(serializers.Serializer):
 
 class E2EDestroySerializer(serializers.Serializer):
     """Serializer for E2E Destroy API payload validation"""
-    workspace_id = serializers.CharField(required=True, help_text="ID of the workspace to destroy")
+    workspace_id = serializers.IntegerField(required=True, help_text="ID of the workspace to destroy")
 
     # Safety constants for allowed workspace names
     ALLOWED_WORKSPACE_NAMES = [
@@ -44,7 +44,7 @@ class E2EDestroySerializer(serializers.Serializer):
             )
         return attrs
 
-    def validate_workspace_id(self, value: str) -> str:
+    def validate_workspace_id(self, value: int) -> int:
         """Validate org ID and perform safety checks"""
         # Find and validate workspace
         try:

--- a/tests/test_internal/fixtures.py
+++ b/tests/test_internal/fixtures.py
@@ -6,12 +6,10 @@ data = {
         'workspace_id': 0,  # Invalid workspace ID (should be > 0)
     },
     'e2e_destroy_payload': {
-        'org_id': 'test_org_123'
+        'workspace_id': 2,
     },
-    'e2e_destroy_empty_org_id_payload': {
-        'org_id': ''  # Empty org_id
-    },
+    'e2e_destroy_empty_payload': {},
     'e2e_destroy_nonexistent_payload': {
-        'org_id': 'nonexistent_org'
+        'workspace_id': 234823,
     }
 }

--- a/tests/test_internal/test_views.py
+++ b/tests/test_internal/test_views.py
@@ -188,13 +188,13 @@ def test_e2e_destroy_view_failures(db, api_client, mocker):
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert 'only available in development/staging environments' in str(response.data)
 
-    # Test 2a: Empty org_id (Org ID is required)
+    # Test 2a: Empty workspace_id (workspace_id is required)
     mocker.patch('apps.internal.serializers.is_safe_environment', return_value=True)
 
-    response = api_client.post(url, internal_data['e2e_destroy_empty_org_id_payload'], format='json')
+    response = api_client.post(url, internal_data['e2e_destroy_empty_payload'], format='json')
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert 'org_id' in response.data
+    assert 'workspace_id' in response.data
 
     # Test 2b: Safety check failed (workspace name not in allowed list)
     mock_unsafe_workspace = mocker.Mock()
@@ -204,8 +204,8 @@ def test_e2e_destroy_view_failures(db, api_client, mocker):
     response = api_client.post(url, internal_data['e2e_destroy_payload'], format='json')
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    org_id_errors = response.data.get('org_id')
-    assert org_id_errors and len(org_id_errors) > 0 and 'Safety check failed' in org_id_errors[0]
+    workspace_id_errors = response.data.get('workspace_id')
+    assert workspace_id_errors and len(workspace_id_errors) > 0 and 'Safety check failed' in workspace_id_errors[0]
 
     # Test 3: Workspace not found
     mocker.patch('apps.internal.serializers.is_safe_environment', return_value=True)
@@ -216,8 +216,8 @@ def test_e2e_destroy_view_failures(db, api_client, mocker):
     response = api_client.post(url, internal_data['e2e_destroy_nonexistent_payload'], format='json')
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    org_id_errors = response.data.get('org_id')
-    assert org_id_errors and len(org_id_errors) > 0 and 'No workspace found' in org_id_errors[0]
+    workspace_id_errors = response.data.get('workspace_id')
+    assert workspace_id_errors and len(workspace_id_errors) > 0 and 'No workspace found' in workspace_id_errors[0]
 
     # Test 4: Integration deletion exception
     mocker.patch('apps.internal.serializers.is_safe_environment', return_value=True)


### PR DESCRIPTION
This makes the payloads of the setup and destroy endpoints consistent.

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the process for destroying workspaces to use workspace IDs instead of organization IDs.
* **Bug Fixes**
  * Improved error messages and payload validation to reflect the use of workspace IDs.
* **Chores**
  * Updated response fields, logging, and test data to consistently reference workspace IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->