### PR TITLE
feat: add caching for sync and refresh calls

### DIFF
--- a/apps/workspaces/enums.py
+++ b/apps/workspaces/enums.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class CacheKeyEnum(str, Enum):
+    """
+    Cache key enum
+    """
+    FYLE_SYNC_DIMENSIONS = "sync_dimensions_{workspace_id}"
+    SAGE_INTACCT_SYNC_DIMENSIONS = "sync_sage_intacct_dimensions_{workspace_id}"

--- a/tests/test_sageintacct/test_views.py
+++ b/tests/test_sageintacct/test_views.py
@@ -1,5 +1,7 @@
 import json
 
+from django.core.cache import cache
+from apps.workspaces.enums import CacheKeyEnum
 from apps.workspaces.models import SageIntacctCredential
 
 
@@ -116,6 +118,8 @@ def test_refresh_dimensions(mocker, api_client, test_connection):
     assert response.status_code == 200
 
     mocker.patch('apps.sage_intacct.views.publish_to_rabbitmq', side_effect=SageIntacctCredential.DoesNotExist)
+
+    cache.get(CacheKeyEnum.SAGE_INTACCT_SYNC_DIMENSIONS.value.format(workspace_id=workspace_id)).delete()
 
     sage_intacct_credentials = SageIntacctCredential.objects.get(workspace_id=workspace_id)
     sage_intacct_credentials.delete()

--- a/tests/test_sageintacct/test_views.py
+++ b/tests/test_sageintacct/test_views.py
@@ -119,7 +119,7 @@ def test_refresh_dimensions(mocker, api_client, test_connection):
 
     mocker.patch('apps.sage_intacct.views.publish_to_rabbitmq', side_effect=SageIntacctCredential.DoesNotExist)
 
-    cache.get(CacheKeyEnum.SAGE_INTACCT_SYNC_DIMENSIONS.value.format(workspace_id=workspace_id)).delete()
+    cache.delete(CacheKeyEnum.SAGE_INTACCT_SYNC_DIMENSIONS.value.format(workspace_id=workspace_id))
 
     sage_intacct_credentials = SageIntacctCredential.objects.get(workspace_id=workspace_id)
     sage_intacct_credentials.delete()


### PR DESCRIPTION
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate Fyle and Sage Intacct dimension syncs by throttling requests per workspace for five minutes.
  * Ensures import/refresh actions are queued or executed only once per trigger, reducing concurrent jobs and accidental repeats.
  * Improves reliability during rapid or repeated sync requests.

* **Chores**
  * Added workspace-scoped short-term caching to coordinate and protect dimension sync operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->